### PR TITLE
EIP-1559 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,10 @@ Create a transaction object and sign it with the default account.
     from ledgereth import create_transaction
     tx = create_transaction(
         '0xb78f53524ae9d465279e7c3495f71d5db2419e13',  # to
-        '0x4dae53ee778a324bd317bd270d6227406b6bd4ec',  # from
         int(1e18),  # value
-        int(1e5),  # gas limit
-        int(1e9),  # gas price
-        1,  # nonce
+        int(1e5),   # gas limit
+        1,          # nonce
+        int(1e9),   # gas price
     )
     signature = '0x{}{}{}'.format(
         hex(tx.v)[2:],

--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ Sign a `Transaction` object from pyethereum(or similar RLP serializable):
 - Add fake dongle support to pytest suite so tests can be run without a real Ledger and human interaction
 - Fill out tests
 - Add messaging signing support
-- Add type 1 transactions (access list)
-- Add EIP-1559 support
+- Add ERC-712 messaging signing support
+- Add type 1 transactions (EIP-2930 access list)

--- a/ledgereth/__main__.py
+++ b/ledgereth/__main__.py
@@ -86,8 +86,23 @@ def get_args(argv):
         "-p",
         "--gasprice",
         type=int,
-        required=True,
+        required=False,
         help="The gas price to use for the tx",
+    )
+    send_parser.add_argument(
+        "-f",
+        "--max-fee",
+        type=int,
+        required=False,
+        help="The max fee per gas to use for the tx",
+    )
+    send_parser.add_argument(
+        "-b",
+        "--bribe",
+        type=int,
+        required=False,
+        default=0,
+        help="The priority fee per gas to use for the tx (default: 0)",
     )
     send_parser.add_argument(
         "-d",
@@ -121,6 +136,13 @@ def send_value(dongle, args):
         dongle.close()
         sys.exit(1)
 
+    if not args.gasprice and not args.max_fee:
+        print(
+            "Either --gasprice or --max-fee must be provided", file=sys.stderr
+        )
+        dongle.close()
+        sys.exit(1)
+
     to_address = args.to_address
 
     signed = create_transaction(
@@ -128,6 +150,8 @@ def send_value(dongle, args):
         value=args.wei,
         gas=args.gas,
         gas_price=args.gasprice,
+        max_fee_per_gas=args.max_fee,
+        bribe_per_gas=args.bribe,
         data=args.data or "",
         nonce=args.nonce,
         chain_id=args.chainid,

--- a/ledgereth/__main__.py
+++ b/ledgereth/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+from enum import IntEnum
 
 from ledgereth import (
     create_transaction,
@@ -8,6 +9,12 @@ from ledgereth import (
     get_accounts,
 )
 from ledgereth.comms import init_dongle
+
+
+class ExitCodes(IntEnum):
+    SUCCESS = 0
+    GENERAL_ERROR = 1
+    INVALID_ARGUMENT = 2
 
 
 def get_args(argv):
@@ -86,21 +93,18 @@ def get_args(argv):
         "-p",
         "--gasprice",
         type=int,
-        required=False,
         help="The gas price to use for the tx",
     )
     send_parser.add_argument(
         "-f",
         "--max-fee",
         type=int,
-        required=False,
         help="The max fee per gas to use for the tx",
     )
     send_parser.add_argument(
         "-b",
-        "--bribe",
+        "--priority-fee",
         type=int,
-        required=False,
         default=0,
         help="The priority fee per gas to use for the tx (default: 0)",
     )
@@ -134,14 +138,14 @@ def send_value(dongle, args):
     if not account:
         print("Account not found on device", file=sys.stderr)
         dongle.close()
-        sys.exit(1)
+        sys.exit(ExitCodes.INVALID_ARGUMENT)
 
     if not args.gasprice and not args.max_fee:
         print(
             "Either --gasprice or --max-fee must be provided", file=sys.stderr
         )
         dongle.close()
-        sys.exit(1)
+        sys.exit(ExitCodes.INVALID_ARGUMENT)
 
     to_address = args.to_address
 
@@ -151,7 +155,7 @@ def send_value(dongle, args):
         gas=args.gas,
         gas_price=args.gasprice,
         max_fee_per_gas=args.max_fee,
-        bribe_per_gas=args.bribe,
+        priority_fee_per_gas=args.priority_fee,
         data=args.data or "",
         nonce=args.nonce,
         chain_id=args.chainid,
@@ -172,7 +176,7 @@ def main(argv=sys.argv[1:]):
 
     if command not in COMMANDS:
         print(f"Invalid command: {command}", file=sys.stderr)
-        sys.exit(1)
+        sys.exit(ExitCodes.INVALID_ARGUMENT)
 
     dongle = init_dongle(debug=args.debug)
     COMMANDS[command](dongle, args)

--- a/ledgereth/_meta.py
+++ b/ledgereth/_meta.py
@@ -1,3 +1,3 @@
 author = "Mike Shultz"
 email = "mike@mikeshultz.com"
-version = "0.2.0"
+version = "0.3.0"

--- a/ledgereth/objects.py
+++ b/ledgereth/objects.py
@@ -121,9 +121,6 @@ class Transaction(rlp.Serializable):
             nonce, gasprice, startgas, to, value, data, chainid, dummy1, dummy2
         )
 
-    def sender(self, value: str) -> None:
-        self._sender = value
-
     def to_dict(self) -> dict:
         d = {}
         for name, _ in self.__class__._meta.fields:
@@ -181,9 +178,6 @@ class Type2Transaction(rlp.Serializable):
             access_list,
         )
 
-    def sender(self, value: str) -> None:
-        self._sender = value
-
     def to_dict(self) -> dict:
         d = {}
         for name, _ in self.__class__._meta.fields:
@@ -220,9 +214,6 @@ class SignedTransaction(rlp.Serializable):
         s: int,
     ):
         super().__init__(nonce, gasprice, startgas, to, value, data, v, r, s)
-
-    def sender(self, value: str) -> None:
-        self._sender = value
 
     def to_dict(self) -> dict:
         d = {}
@@ -293,9 +284,6 @@ class SignedType2Transaction(rlp.Serializable):
             sender_r,
             sender_s,
         )
-
-    def sender(self, value: str) -> None:
-        self._sender = value
 
     def to_dict(self) -> dict:
         d = {}

--- a/ledgereth/objects.py
+++ b/ledgereth/objects.py
@@ -1,9 +1,24 @@
 import rlp
+from enum import IntEnum
+from typing import List
+
 from eth_utils import encode_hex, to_checksum_address
-from rlp.sedes import Binary, big_endian_int, binary
+from rlp.sedes import Binary, big_endian_int, binary, List as ListSedes
 
 from ledgereth.constants import DEFAULT_CHAIN_ID
 from ledgereth.utils import is_bip32_path, is_bytes, parse_bip32_path
+
+
+class TransactionType(IntEnum):
+    # Original and EIP-155
+    LEGACY = 0
+    # Access Lists
+    EIP_2930 = 1
+    # Transaction fee change to max fee and bribe
+    EIP_1559 = 2
+
+    def to_byte(self):
+        return self.value.to_bytes(1, "big")
 
 
 class ISO7816Command:
@@ -74,6 +89,8 @@ class LedgerAccount:
 
 
 class Transaction(rlp.Serializable):
+    """Unsigned legacy or EIP-155 transaction"""
+
     fields = [
         ("nonce", big_endian_int),
         ("gasprice", big_endian_int),
@@ -86,6 +103,7 @@ class Transaction(rlp.Serializable):
         ("dummy1", big_endian_int),
         ("dummy2", big_endian_int),
     ]
+    transaction_type = TransactionType.LEGACY
 
     def __init__(
         self,
@@ -94,12 +112,12 @@ class Transaction(rlp.Serializable):
         startgas: int,
         to: bytes,
         value: int,
-        data: str,
+        data: bytes,
         chainid: int = DEFAULT_CHAIN_ID,
         dummy1: int = 0,
         dummy2: int = 0,
     ):
-        super(RLPTx, self).__init__(
+        super().__init__(
             nonce, gasprice, startgas, to, value, data, chainid, dummy1, dummy2
         )
 
@@ -113,7 +131,69 @@ class Transaction(rlp.Serializable):
         return d
 
 
+class Type2Transaction(rlp.Serializable):
+    """An unsigned Type 2 transaction.
+
+    Format spec:
+
+    0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list])
+
+    Note: access_list is not actually implemented yet.
+    """
+
+    fields = [
+        ("chain_id", big_endian_int),
+        ("nonce", big_endian_int),
+        ("max_priority_fee_per_gas", big_endian_int),
+        ("max_fee_per_gas", big_endian_int),
+        ("gas_limit", big_endian_int),
+        ("destination", Binary.fixed_length(20, allow_empty=True)),
+        ("amount", big_endian_int),
+        ("data", binary),
+        # TODO: This only supports empty lists and needs to be fixed for
+        # EIP-2930 support
+        ("access_list", ListSedes()),
+    ]
+    transaction_type = TransactionType.EIP_1559
+
+    def __init__(
+        self,
+        chain_id: int,
+        nonce: int,
+        max_priority_fee_per_gas: int,
+        max_fee_per_gas: int,
+        gas_limit: int,
+        destination: bytes,
+        amount: int,
+        data: bytes,
+        # TODO: Access lists, type 1 transactions
+        access_list: List[bytes] = list(),
+    ):
+        super().__init__(
+            chain_id,
+            nonce,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            gas_limit,
+            destination,
+            amount,
+            data,
+            access_list,
+        )
+
+    def sender(self, value: str) -> None:
+        self._sender = value
+
+    def to_dict(self) -> dict:
+        d = {}
+        for name, _ in self.__class__._meta.fields:
+            d[name] = getattr(self, name)
+        return d
+
+
 class SignedTransaction(rlp.Serializable):
+    """Signed legacy or EIP-155 transaction"""
+
     fields = [
         ("nonce", big_endian_int),
         ("gasprice", big_endian_int),
@@ -125,6 +205,7 @@ class SignedTransaction(rlp.Serializable):
         ("r", big_endian_int),
         ("s", big_endian_int),
     ]
+    transaction_type = TransactionType.LEGACY
 
     def __init__(
         self,
@@ -133,7 +214,7 @@ class SignedTransaction(rlp.Serializable):
         startgas: int,
         to: bytes,
         value: int,
-        data: str,
+        data: bytes,
         v: int,
         r: int,
         s: int,
@@ -151,6 +232,79 @@ class SignedTransaction(rlp.Serializable):
 
     def raw_transaction(self):
         return encode_hex(rlp.encode(self, SignedTransaction))
+
+    # Match the API of the web3.py Transaction object
+    rawTransaction = property(raw_transaction)
+
+
+class SignedType2Transaction(rlp.Serializable):
+    """A signed Type 2 transaction.
+
+    Format spec:
+
+    0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r, signature_s])
+    """
+
+    fields = [
+        ("chain_id", big_endian_int),
+        ("nonce", big_endian_int),
+        ("max_priority_fee_per_gas", big_endian_int),
+        ("max_fee_per_gas", big_endian_int),
+        ("gas_limit", big_endian_int),
+        ("destination", Binary.fixed_length(20, allow_empty=True)),
+        ("amount", big_endian_int),
+        ("data", binary),
+        # TODO: This only supports empty lists and needs to be fixed for
+        # EIP-2930 support
+        ("access_list", ListSedes()),
+        ("y_parity", big_endian_int),
+        ("sender_r", big_endian_int),
+        ("sender_s", big_endian_int),
+    ]
+    transaction_type = TransactionType.EIP_1559
+
+    def __init__(
+        self,
+        chain_id: int,
+        nonce: int,
+        max_priority_fee_per_gas: int,
+        max_fee_per_gas: int,
+        gas_limit: int,
+        destination: bytes,
+        amount: int,
+        data: bytes,
+        # TODO: Access lists, type 1 transactions
+        access_list: List[bytes],
+        y_parity: int,
+        sender_r: int,
+        sender_s: int,
+    ):
+        super().__init__(
+            chain_id,
+            nonce,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            gas_limit,
+            destination,
+            amount,
+            data,
+            access_list,
+            y_parity,
+            sender_r,
+            sender_s,
+        )
+
+    def sender(self, value: str) -> None:
+        self._sender = value
+
+    def to_dict(self) -> dict:
+        d = {}
+        for name, _ in self.__class__._meta.fields:
+            d[name] = getattr(self, name)
+        return d
+
+    def raw_transaction(self):
+        return encode_hex(b"\x02" + rlp.encode(self, SignedType2Transaction))
 
     # Match the API of the web3.py Transaction object
     rawTransaction = property(raw_transaction)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
-import ledgereth
 from pathlib import Path
 
 from setuptools import find_packages, setup
 from importlib.machinery import SourceFileLoader
-
-import ledgereth
 
 pwd = Path(__file__).parent
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -9,81 +9,88 @@ from ledgereth.transactions import create_transaction, sign_transaction
 def test_pre_155_send(yield_dongle):
     """Test sending a transaction without EIP-155 (old style), without a chain
     ID"""
-    # One can also use create_transaction(), this is ust to add some coverage
-    tx = Transaction(
-        to=decode_hex("0xf0155486a14539f784739be1c02e93f28eb8e960"),
-        value=int(1e17),
-        startgas=int(1e6),
-        gasprice=int(1e9),
-        data=b"",
-        nonce=0,
-    )
-    signed = sign_transaction(tx)
+    with yield_dongle() as dongle:
+        # One can also use create_transaction(), this is ust to add some coverage
+        tx = Transaction(
+            to=decode_hex("0xf0155486a14539f784739be1c02e93f28eb8e960"),
+            value=int(1e17),
+            startgas=int(1e6),
+            gasprice=int(1e9),
+            data=b"",
+            nonce=0,
+        )
+        signed = sign_transaction(tx, dongle=dongle)
 
-    assert signed.v in (37, 38)
-    assert signed.r
-    assert signed.s
+        assert signed.v in (37, 38)
+        assert signed.r
+        assert signed.s
 
 
 def test_mainnet_send(yield_dongle):
     """Test a mainnet transaction"""
     CHAIN_ID = 1
 
-    signed = create_transaction(
-        to="0xf0155486a14539f784739be1c02e93f28eb8e960",
-        value=int(1e17),
-        gas=int(1e6),
-        gas_price=int(1e9),
-        data="",
-        nonce=0,
-        chain_id=CHAIN_ID,
-    )
+    with yield_dongle() as dongle:
+        signed = create_transaction(
+            to="0xf0155486a14539f784739be1c02e93f28eb8e960",
+            value=int(1e17),
+            gas=int(1e6),
+            gas_price=int(1e9),
+            data="",
+            nonce=0,
+            chain_id=CHAIN_ID,
+            dongle=dongle,
+        )
 
-    assert signed.v in [(CHAIN_ID * 2 + 35) + x for x in (0, 1)]
-    assert signed.r
-    assert signed.s
+        assert signed.v in [(CHAIN_ID * 2 + 35) + x for x in (0, 1)]
+        assert signed.r
+        assert signed.s
 
 
 def test_rinkeby_send(yield_dongle):
     """Test a rinkeby transaction"""
     CHAIN_ID = 4
 
-    signed = create_transaction(
-        to="0xf0155486a14539f784739be1c02e93f28eb8e960",
-        value=int(1e17),
-        gas=int(1e6),
-        gas_price=int(1e9),
-        data="",
-        nonce=0,
-        chain_id=CHAIN_ID,
-    )
+    with yield_dongle() as dongle:
+        signed = create_transaction(
+            to="0xf0155486a14539f784739be1c02e93f28eb8e960",
+            value=int(1e17),
+            gas=int(1e6),
+            gas_price=int(1e9),
+            data="",
+            nonce=0,
+            chain_id=CHAIN_ID,
+            dongle=dongle,
+        )
 
-    assert signed.v in [(CHAIN_ID * 2 + 35) + x for x in (0, 1)]
-    assert signed.r
-    assert signed.s
+        assert signed.v in [(CHAIN_ID * 2 + 35) + x for x in (0, 1)]
+        assert signed.r
+        assert signed.s
 
 
 def test_eip1559_send(yield_dongle):
     """Test a type 2 (EIP-1559) transaction"""
     CHAIN_ID = 3
-    bribe_per_gas = int(1e9)
+    priority_fee_per_gas = int(1e9)
     max_fee_per_gas = int(20e9)
 
-    # Matches tx from app-ethereum tests
-    signed = create_transaction(
-        to="0xb2bb2b958afa2e96dab3f3ce7162b87daea39017",
-        value=int(1e16),  # 0.01 ETH
-        gas=21000,
-        bribe_per_gas=bribe_per_gas,
-        max_fee_per_gas=max_fee_per_gas,
-        data="",
-        nonce=6,
-        chain_id=CHAIN_ID,
-    )
+    with yield_dongle() as dongle:
+        # Matches tx from app-ethereum tests
+        signed = create_transaction(
+            to="0xb2bb2b958afa2e96dab3f3ce7162b87daea39017",
+            value=int(1e16),  # 0.01 ETH
+            gas=21000,
+            priority_fee_per_gas=priority_fee_per_gas,
+            max_fee_per_gas=max_fee_per_gas,
+            data="",
+            nonce=6,
+            chain_id=CHAIN_ID,
+            dongle=dongle,
+        )
 
-    assert signed.max_priority_fee_per_gas == bribe_per_gas
-    assert signed.max_fee_per_gas == max_fee_per_gas
-    # Transaactions after EIP-2930 use a parity byte instead of "v"
-    assert signed.y_parity in (1, 2)
-    assert signed.sender_r
-    assert signed.sender_s
+        assert signed.max_priority_fee_per_gas == priority_fee_per_gas
+        assert signed.max_fee_per_gas == max_fee_per_gas
+        # Transaactions after EIP-2930 use a parity byte instead of "v"
+        assert signed.y_parity in (1, 2)
+        assert signed.sender_r
+        assert signed.sender_s

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -61,3 +61,29 @@ def test_rinkeby_send(yield_dongle):
     assert signed.v in [(CHAIN_ID * 2 + 35) + x for x in (0, 1)]
     assert signed.r
     assert signed.s
+
+
+def test_eip1559_send(yield_dongle):
+    """Test a type 2 (EIP-1559) transaction"""
+    CHAIN_ID = 3
+    bribe_per_gas = int(1e9)
+    max_fee_per_gas = int(20e9)
+
+    # Matches tx from app-ethereum tests
+    signed = create_transaction(
+        to="0xb2bb2b958afa2e96dab3f3ce7162b87daea39017",
+        value=int(1e16),  # 0.01 ETH
+        gas=21000,
+        bribe_per_gas=bribe_per_gas,
+        max_fee_per_gas=max_fee_per_gas,
+        data="",
+        nonce=6,
+        chain_id=CHAIN_ID,
+    )
+
+    assert signed.max_priority_fee_per_gas == bribe_per_gas
+    assert signed.max_fee_per_gas == max_fee_per_gas
+    # Transaactions after EIP-2930 use a parity byte instead of "v"
+    assert signed.y_parity in (1, 2)
+    assert signed.sender_r
+    assert signed.sender_s


### PR DESCRIPTION
Adds EIP-1559 support.  Does not include EIP-2930 Type 1 transaction support (specifically access lists), but it lays the groundwork.  Needs some more work on RLP encoding of access lists.

Closes #9