### PR TITLE
Type 1 transactions support 

### DIFF
--- a/ledgereth/__init__.py
+++ b/ledgereth/__init__.py
@@ -1,12 +1,21 @@
 # flake8:noqa
 from ledgereth._meta import author, email, version
-from ledgereth.objects import Transaction, SignedTransaction
+from ledgereth.objects import (
+    Transaction,
+    Type1Transaction,
+    Type2Transaction,
+    SignedTransaction,
+    SignedType1Transaction,
+    SignedType2Transaction,
+)
 from ledgereth.accounts import find_account, get_account_by_path, get_accounts
 from ledgereth.transactions import sign_transaction, create_transaction
 
 __all__ = [
     "Transaction",
-    "SignedTransaction",
+    "Type1Transaction" "Type2Transaction" "SignedTransaction",
+    "SignedType1Transaction",
+    "SignedType2Transaction",
     "find_account",
     "get_account_by_path",
     "get_accounts",

--- a/ledgereth/__main__.py
+++ b/ledgereth/__main__.py
@@ -150,12 +150,12 @@ def send_value(dongle, args):
     to_address = args.to_address
 
     signed = create_transaction(
-        to=to_address,
-        value=args.wei,
+        destination=to_address,
+        amount=args.wei,
         gas=args.gas,
         gas_price=args.gasprice,
         max_fee_per_gas=args.max_fee,
-        priority_fee_per_gas=args.priority_fee,
+        max_priority_fee_per_gas=args.priority_fee,
         data=args.data or "",
         nonce=args.nonce,
         chain_id=args.chainid,

--- a/ledgereth/objects.py
+++ b/ledgereth/objects.py
@@ -183,7 +183,7 @@ class Type1Transaction(rlp.Serializable):
         destination: bytes,
         amount: int,
         data: bytes,
-        access_list: List[Tuple[bytes, List[bytes]]] = list(),
+        access_list: List[Tuple[bytes, List[int]]] = list(),
     ):
         super().__init__(
             chain_id,
@@ -234,7 +234,7 @@ class Type2Transaction(rlp.Serializable):
         destination: bytes,
         amount: int,
         data: bytes,
-        access_list: List[Tuple[bytes, List[bytes]]] = list(),
+        access_list: List[Tuple[bytes, List[int]]] = list(),
     ):
         super().__init__(
             chain_id,
@@ -332,7 +332,7 @@ class SignedType1Transaction(rlp.Serializable):
         destination: bytes,
         amount: int,
         data: bytes,
-        access_list: List[bytes],
+        access_list: List[Tuple[bytes, List[int]]],
         y_parity: int,
         sender_r: int,
         sender_s: int,
@@ -398,7 +398,7 @@ class SignedType2Transaction(rlp.Serializable):
         destination: bytes,
         amount: int,
         data: bytes,
-        access_list: List[bytes],
+        access_list: List[Tuple[bytes, List[int]]],
         y_parity: int,
         sender_r: int,
         sender_s: int,

--- a/ledgereth/transactions.py
+++ b/ledgereth/transactions.py
@@ -181,7 +181,7 @@ def create_transaction(
     max_fee_per_gas: int = 0,
     chain_id: int = DEFAULT_CHAIN_ID,
     sender_path: str = DEFAULT_PATH_STRING,
-    access_list: Optional[List[Tuple[bytes, List[bytes]]]] = None,
+    access_list: Optional[List[Tuple[bytes, List[int]]]] = None,
     dongle: Any = None,
 ) -> SignedTransaction:
     """Create and sign a transaction from indiv args"""

--- a/ledgereth/transactions.py
+++ b/ledgereth/transactions.py
@@ -1,5 +1,5 @@
 import binascii
-from typing import Any, Union
+from typing import Any, List, Optional, Tuple, Union
 
 from eth_utils import decode_hex
 from rlp import Serializable, encode
@@ -8,9 +8,11 @@ from ledgereth.comms import chunks, dongle_send_data, init_dongle
 from ledgereth.constants import DEFAULT_CHAIN_ID, DEFAULT_PATH_STRING
 from ledgereth.objects import (
     SignedTransaction,
+    SignedType1Transaction,
     SignedType2Transaction,
     Transaction,
     TransactionType,
+    Type1Transaction,
     Type2Transaction,
 )
 from ledgereth.utils import is_bip32_path, is_hex_string, parse_bip32_path
@@ -18,12 +20,39 @@ from ledgereth.utils import is_bip32_path, is_hex_string, parse_bip32_path
 Text = Union[str, bytes]
 
 
-def tx_chain_id(tx):
-    if hasattr(tx, "chainid"):
-        return tx.chainid
-    elif hasattr(tx, "chain_id"):
-        return tx.chain_id
-    return DEFAULT_CHAIN_ID
+def coerce_access_list(access_list):
+    """validate and type coerce an access list"""
+    if access_list is None:
+        return []
+
+    if type(access_list) != list:
+        raise ValueError("Expected access_list to be a list")
+
+    for i, rule in enumerate(access_list):
+        if type(rule) not in (list, tuple):
+            raise ValueError("Expected access_list rules to be a list or tuple")
+
+        if type(rule) == tuple:
+            access_list[i] = list(rule)
+
+        target, slots = rule
+
+        if is_hex_string(target):
+            access_list[i][0] = decode_hex(target)
+        elif type(target) != bytes:
+            raise ValueError(
+                f"Unexpected type ({type(target)}) for access_list address at index {i}"
+            )
+
+        for j, slot in enumerate(slots):
+            if is_hex_string(slot):
+                access_list[i][1][j] = int(slot, 16)
+            elif type(slot) != int:
+                raise ValueError(
+                    f"Unexpected type ({type(slot)}) for access_list slot at index {j}"
+                )
+
+    return access_list
 
 
 def sign_transaction(
@@ -38,6 +67,10 @@ def sign_transaction(
 
     if isinstance(tx, Transaction):
         encoded_tx = encode(tx, Transaction)
+    elif isinstance(tx, Type1Transaction):
+        encoded_tx = tx.transaction_type.to_byte() + encode(
+            tx, Type1Transaction
+        )
     elif isinstance(tx, Type2Transaction):
         encoded_tx = tx.transaction_type.to_byte() + encode(
             tx, Type2Transaction
@@ -75,7 +108,7 @@ def sign_transaction(
     if retval is None or len(retval) < 64:
         raise Exception("Invalid response from Ledger")
 
-    chain_id = tx_chain_id(tx)
+    chain_id = tx.chain_id or DEFAULT_CHAIN_ID
     r = int(binascii.hexlify(retval[1:33]), 16)
     s = int(binascii.hexlify(retval[33:65]), 16)
 
@@ -88,10 +121,10 @@ def sign_transaction(
 
         signed = SignedTransaction(
             nonce=tx.nonce,
-            gasprice=tx.gasprice,
-            startgas=tx.startgas,
-            to=tx.to,
-            value=tx.value,
+            gas_price=tx.gas_price,
+            gas_limit=tx.gas_limit,
+            destination=tx.destination,
+            amount=tx.amount,
             data=tx.data,
             v=v,
             r=r,
@@ -100,20 +133,35 @@ def sign_transaction(
     else:
         y_parity = retval[0]
 
-        signed = SignedType2Transaction(
-            chain_id=tx.chain_id,
-            nonce=tx.nonce,
-            gas_limit=tx.gas_limit,
-            destination=tx.destination,
-            amount=tx.amount,
-            data=tx.data,
-            max_priority_fee_per_gas=tx.max_priority_fee_per_gas,
-            max_fee_per_gas=tx.max_fee_per_gas,
-            access_list=tx.access_list,
-            y_parity=y_parity,
-            sender_r=r,
-            sender_s=s,
-        )
+        if tx.transaction_type == TransactionType.EIP_2930:
+            signed = SignedType1Transaction(
+                chain_id=tx.chain_id,
+                nonce=tx.nonce,
+                gas_limit=tx.gas_limit,
+                destination=tx.destination,
+                amount=tx.amount,
+                data=tx.data,
+                gas_price=tx.gas_price,
+                access_list=tx.access_list,
+                y_parity=y_parity,
+                sender_r=r,
+                sender_s=s,
+            )
+        else:
+            signed = SignedType2Transaction(
+                chain_id=tx.chain_id,
+                nonce=tx.nonce,
+                gas_limit=tx.gas_limit,
+                destination=tx.destination,
+                amount=tx.amount,
+                data=tx.data,
+                max_priority_fee_per_gas=tx.max_priority_fee_per_gas,
+                max_fee_per_gas=tx.max_fee_per_gas,
+                access_list=tx.access_list,
+                y_parity=y_parity,
+                sender_r=r,
+                sender_s=s,
+            )
 
     # If this func inited the dongle, it close it, otherwise core dump
     if not given_dongle:
@@ -123,32 +171,35 @@ def sign_transaction(
 
 
 def create_transaction(
-    to: Text,
-    value: int,
+    destination: Text,
+    amount: int,
     gas: int,
     nonce: int,
     data: Text = b"",
     gas_price: int = 0,
-    priority_fee_per_gas: int = 0,
+    max_priority_fee_per_gas: int = 0,
     max_fee_per_gas: int = 0,
     chain_id: int = DEFAULT_CHAIN_ID,
     sender_path: str = DEFAULT_PATH_STRING,
+    access_list: Optional[List[Tuple[bytes, List[bytes]]]] = None,
     dongle: Any = None,
 ) -> SignedTransaction:
     """Create and sign a transaction from indiv args"""
     given_dongle = dongle is not None
     dongle = init_dongle(dongle)
 
-    if is_hex_string(to):
-        to = decode_hex(to)
+    if is_hex_string(destination):
+        destination = decode_hex(destination)
 
-    if not data or is_hex_string(data):
+    if not data:
+        data = b""
+    elif is_hex_string(data):
         data = decode_hex(data)
 
     # EIP-1559 transactions should never have gas_price
-    if gas_price and (priority_fee_per_gas or max_fee_per_gas):
+    if gas_price and (max_priority_fee_per_gas or max_fee_per_gas):
         raise ValueError(
-            "gas_price is incompatible with priority_fee_per_gas and max_fee_per_gas"
+            "gas_price is incompatible with max_priority_fee_per_gas and max_fee_per_gas"
         )
 
     # we need a gas price for a valid transaction
@@ -158,24 +209,36 @@ def create_transaction(
     # Create a serializable tx object
     if max_fee_per_gas:
         tx = Type2Transaction(
-            destination=to,
-            amount=value,
+            destination=destination,
+            amount=amount,
             gas_limit=gas,
             data=data,
             nonce=nonce,
             chain_id=chain_id,
-            max_priority_fee_per_gas=priority_fee_per_gas,
+            max_priority_fee_per_gas=max_priority_fee_per_gas,
             max_fee_per_gas=max_fee_per_gas,
+            access_list=coerce_access_list(access_list),
+        )
+    elif access_list is not None:
+        tx = Type1Transaction(
+            destination=destination,
+            amount=amount,
+            gas_limit=gas,
+            data=data,
+            nonce=nonce,
+            chain_id=chain_id,
+            gas_price=gas_price,
+            access_list=coerce_access_list(access_list),
         )
     else:
         tx = Transaction(
-            to=to,
-            value=value,
-            startgas=gas,
-            gasprice=gas_price,
+            destination=destination,
+            amount=amount,
+            gas_limit=gas,
+            gas_price=gas_price,
             data=data,
             nonce=nonce,
-            chainid=chain_id,
+            chain_id=chain_id,
         )
 
     signed = sign_transaction(tx, sender_path, dongle=dongle)


### PR DESCRIPTION
Adds support for type 1 transactions and access lists.  Also standardizes prop names on the transaction objects.

Closes #12