### PR TITLE
fix: throw errors on chain IDs above what app-ethereum plays well with

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,8 @@ class MockDongle:
         self.stack = []
 
     def _resp_to_bytearray(self, resp):
-        # for large chain_id, v can be bigger than a byte. we'll take the lowest byte for the signature
+        # for large chain_id, v can be bigger than a byte. we'll take the lowest
+        # byte for the signature
         v = resp.v.to_bytes(8, "big")[7].to_bytes(1, "big")
         r = resp.r.to_bytes(32, "big")
         s = resp.s.to_bytes(32, "big")

--- a/tests/test_chain_id.py
+++ b/tests/test_chain_id.py
@@ -1,0 +1,143 @@
+"""Test signing for multiple chains"""
+import pytest
+from eth_account import Account
+
+from ledgereth.accounts import get_accounts
+from ledgereth.objects import MAX_CHAIN_ID, MAX_LEGACY_CHAIN_ID
+from ledgereth.transactions import create_transaction
+
+
+def test_max_legacy_chain_ids(yield_dongle):
+    """Test that the max legacy chain ID works"""
+    destination = "0xf0155486a14539f784739be1c02e93f28eb8e900"
+
+    with yield_dongle() as dongle:
+        sender = get_accounts(dongle=dongle, count=1)[0].address
+
+        signed = create_transaction(
+            destination=destination,
+            amount=int(10e17),
+            gas=int(1e6),
+            gas_price=int(1e9),
+            data="",
+            nonce=2023,
+            chain_id=MAX_LEGACY_CHAIN_ID,
+            dongle=dongle,
+        )
+
+        assert sender == Account.recover_transaction(signed.rawTransaction)
+
+
+def test_invalid_legacy_chain_ids(yield_dongle):
+    """Test that chain IDs above max legacy chain ID fail"""
+    destination = "0xf0155486a14539f784739be1c02e93f28eb8e901"
+
+    with yield_dongle() as dongle:
+        sender = get_accounts(dongle=dongle, count=1)[0].address
+
+        with pytest.raises(
+            ValueError,
+            match="chain_id must be a 32-bit integer for type 0 transactions",
+        ):
+            create_transaction(
+                destination=destination,
+                amount=int(10e17),
+                gas=int(1e6),
+                gas_price=int(1e9),
+                data="",
+                nonce=2023,
+                chain_id=MAX_LEGACY_CHAIN_ID + 1,
+                dongle=dongle,
+            )
+
+
+def test_max_type1_chain_ids(yield_dongle):
+    """Test that the max type-1 chain ID works"""
+    destination = "0xf0155486a14539f784739be1c02e93f28eb8e902"
+
+    with yield_dongle() as dongle:
+        sender = get_accounts(dongle=dongle, count=1)[0].address
+
+        signed = create_transaction(
+            destination=destination,
+            amount=int(10e17),
+            gas=int(1e6),
+            access_list=[],
+            gas_price=int(1e9),
+            data="",
+            nonce=2023,
+            chain_id=MAX_CHAIN_ID,
+            dongle=dongle,
+        )
+
+        assert sender == Account.recover_transaction(signed.rawTransaction)
+
+
+def test_invalid_type1_chain_ids(yield_dongle):
+    """Test that IDs above the max chain ID fail"""
+    destination = "0xf0155486a14539f784739be1c02e93f28eb8e903"
+
+    with yield_dongle() as dongle:
+        sender = get_accounts(dongle=dongle, count=1)[0].address
+
+        with pytest.raises(
+            ValueError,
+            match="chain_id must not be above 999999999999999",
+        ):
+            create_transaction(
+                destination=destination,
+                amount=int(10e17),
+                gas=int(1e6),
+                access_list=[],
+                gas_price=int(1e9),
+                data="",
+                nonce=2023,
+                chain_id=MAX_CHAIN_ID + 1,
+                dongle=dongle,
+            )
+
+
+def test_max_type2_chain_ids(yield_dongle):
+    """Test that the max chain ID works for type-2 transactions"""
+    destination = "0xf0155486a14539f784739be1c02e93f28eb8e904"
+
+    with yield_dongle() as dongle:
+        sender = get_accounts(dongle=dongle, count=1)[0].address
+
+        signed = create_transaction(
+            destination=destination,
+            amount=int(10e17),
+            gas=int(1e6),
+            max_fee_per_gas=int(1e9),
+            max_priority_fee_per_gas=int(1e8),
+            data="",
+            nonce=2023,
+            chain_id=MAX_CHAIN_ID,
+            dongle=dongle,
+        )
+
+        assert sender == Account.recover_transaction(signed.rawTransaction)
+
+
+def test_invalid_type2_chain_ids(yield_dongle):
+    """Test that IDs above the max chain ID fail for type-2 transactions"""
+    destination = "0xf0155486a14539f784739be1c02e93f28eb8e905"
+
+    with yield_dongle() as dongle:
+        sender = get_accounts(dongle=dongle, count=1)[0].address
+
+        with pytest.raises(
+            ValueError,
+            match="chain_id must not be above 999999999999999",
+        ):
+            create_transaction(
+                destination=destination,
+                amount=int(10e17),
+                gas=int(1e6),
+                max_fee_per_gas=int(1e9),
+                max_priority_fee_per_gas=int(1e8),
+                data="",
+                nonce=2023,
+                chain_id=MAX_CHAIN_ID + 1,
+                dongle=dongle,
+            )

--- a/tests/test_web3.py
+++ b/tests/test_web3.py
@@ -4,6 +4,7 @@ from eth_utils import encode_hex
 from web3 import Web3
 from web3.datastructures import AttributeDict
 from web3.providers.eth_tester import EthereumTesterProvider
+from web3.providers.eth_tester.defaults import API_ENDPOINTS, static_return
 from web3.types import TxReceipt, Wei
 
 from ledgereth.accounts import get_accounts
@@ -38,7 +39,11 @@ def fund_account(web3: Web3, address: str, amount: int = int(1e18)) -> TxReceipt
 
 def test_web3_middleware_legacy(yield_dongle):
     """Test LedgerSignerMiddleware with a legacy transaction"""
-    provider = EthereumTesterProvider()
+    endpoints = {**API_ENDPOINTS}
+    # Max chain ID for legacy transactions
+    # Ref: https://github.com/mikeshultz/ledger-eth-lib/issues/41
+    endpoints["eth"]["chainId"] = static_return(4294967295)
+    provider = EthereumTesterProvider(api_endpoints=endpoints)
     web3 = Web3(provider)
     clean_web3 = Web3(provider)
     alice_address = web3.eth.accounts[0]


### PR DESCRIPTION
Throw errors on chain IDs app-ethereum cannot handle.

Thanks to @antazoey for the tip on setting the `eth_chainId` RPC response for `EthereumTesterProvider` to fix the web3.py tests.

Ref #41