### PR TITLE
Add __eq__ and __hash__ methods for LedgerAccount

### DIFF
--- a/ledgereth/objects.py
+++ b/ledgereth/objects.py
@@ -180,6 +180,14 @@ class LedgerAccount:
     def __repr__(self):
         return f"<ledgereth.objects.LedgerAccount {self.address}>"
 
+    def __eq__(self, other):
+        if isinstance(other, LedgerAccount):
+            return self.path == other.path and self.address == other.address
+        return False
+
+    def __hash__(self):
+        return hash((self.path, self.address))
+
 
 class SerializableTransaction(Serializable):
     """An RLP Serializable transaction object"""


### PR DESCRIPTION
Closes #50 
This PR defines` __eq__` and `__hash__` methods on `LedgerAccount` class to makes possible that instances of `LedgerAccount` with the same `path` and `address` were evaluated as equals. 
```
In [2]: LedgerAccount("44'/60'/0'/0/10", 0x85bC4dc18e2Dde71294EA1c87CF0824A4c04489D) == LedgerAccount("44'/60'/0'/0/10", 0x85bC4dc18e2Dde71294EA1c87CF0824A4c04489D)
Out[2]: True
```